### PR TITLE
Update default net to nn-9931db908a9b.nnue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,6 +151,7 @@ Sami Kiminki (skiminki)
 Sebastian Buchwald (UniQP)
 Sergei Antonov (saproj)
 Sergei Ivanov (svivanov72)
+Sergio Vieri (sergiovieri)
 sf-x
 Shane Booth (shane31)
 Shawn Varghese (xXH4CKST3RXx)

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -79,7 +79,7 @@ void init(OptionsMap& o) {
   o["Syzygy50MoveRule"]      << Option(true);
   o["SyzygyProbeLimit"]      << Option(7, 0, 7);
   o["Use NNUE"]              << Option(false, on_use_NNUE);
-  o["EvalFile"]              << Option("nn-97f742aaefcd.nnue", on_eval_file);
+  o["EvalFile"]              << Option("nn-9931db908a9b.nnue", on_eval_file);
 }
 
 


### PR DESCRIPTION
Net created at 20200806-1802

passed STC:
https://tests.stockfishchess.org/tests/view/5f2d00b461e3b6af64881f21
LLR: 2.94 (-2.94,2.94) {-0.50,1.50}
Total: 6672 W: 1052 L: 898 D: 4722
Ptnml(0-2): 63, 600, 1868, 730, 75

passed LTC:
https://tests.stockfishchess.org/tests/view/5f2d052a61e3b6af64881f29
LLR: 2.96 (-2.94,2.94) {0.25,1.75}
Total: 7576 W: 573 L: 463 D: 6540
Ptnml(0-2): 8, 392, 2889, 480, 19

closes https://github.com/official-stockfish/Stockfish/pull/2923

Bench: 4390086